### PR TITLE
Update pombo.conf

### DIFF
--- a/pombo.conf
+++ b/pombo.conf
@@ -131,10 +131,10 @@ network_trafic=netstat -n
 ; [L] DISPLAY=:0 su <user> -c "/usr/bin/scrot -z -m -q 50 <filepath>"
 ; [L] DISPLAY=:1 su <user> -c "/usr/bin/scrot -z -m -q 50 <filepath>"
 ; [L] DISPLAY=:0.0 su <user> -c "/usr/bin/scrot -z -m -q 50 <filepath>"
-; [L] /usr/bin/import -window root <filepath>
-; [L] /usr/bin/import -display :0 -window root -quality 50 <filepath>
-; [L] /usr/bin/import -display :1 -window root -quality 50 <filepath>
-; [L] /usr/bin/import -display :0.0 -window root -quality 50 <filepath>
+; [L] /usr/bin/import -silent -window root <filepath>
+; [L] /usr/bin/import -silent -display :0 -window root -quality 50 <filepath>
+; [L] /usr/bin/import -silent -display :1 -window root -quality 50 <filepath>
+; [L] /usr/bin/import -silent -display :0.0 -window root -quality 50 <filepath>
 ; [L] /usr/bin/streamer -c /dev/video0 -b 16 -o <filepath>
 ; [M] /usr/sbin/screencapture -x -tjpg -T1 <filepath>
 screenshot=yes


### PR DESCRIPTION
The _import_ command rings a bell when takijng a screenshot.
It can be avoided by _-silent_ option.