### PR TITLE
fixed 3 issues

### DIFF
--- a/gnu-linux/install.sh
+++ b/gnu-linux/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 #
 # Installation script for Pombo.
 #
@@ -11,15 +11,19 @@ fi
 inst_dir=/usr/local/bin
 [ -d ${inst_dir} ] || inst_dir=/usr/local/sbin
 
-src_dir=""
-[ -f pombo.py ] || src_dir="../"
+script=$(readlink -f "$0")
+# Absolute path install.sh script is in
+src_dir=$(dirname "$script")
+# Absolute path of Pombo main dir (without trailing /)
+src_dir=$(dirname "$src_dir")
+
 
 echo "\nInstalling (verbose) ..."
 [ -f /etc/pombo.conf ] && mv -fv /etc/pombo.conf /etc/pombo.conf.$(date '+%s')
-install -v ${src_dir}pombo.conf /etc
+install -v ${src_dir}/pombo.conf /etc
 echo "« chmod 600 /etc/pombo.conf »"
 chmod 600 /etc/pombo.conf
-install -v ${src_dir}pombo.py ${inst_dir}/pombo
+install -v ${src_dir}/pombo.py ${inst_dir}/pombo
 echo "« chmod +x ${inst_dir}/pombo »"
 chmod +x ${inst_dir}/pombo
 
@@ -43,12 +47,13 @@ echo "Done."
 
 echo "\nChecking dependancies ..."
 ok=1
-for package in python gpg ifconfig iwlist traceroute streamer; do
+
+for package in python gpg ifconfig iwlist traceroute streamer; do    
     test=$(which ${package})
-    [ $? != 0 ] && echo " ! ${package} needed but not installed." && ok=0
+    [ $? != 0 ] && echo " ! ${test}.... ${package} needed but not installed." && ok=0
 done
-python check-imports.py
-[ $? != 0 ] && ok=0
+echo "Shell script uses Python $(python --version)"
+python ${src_dir}/tools/check-imports.py
 case ${ok} in
     1) echo "Done." ;;
     *) echo "Please install necessary tools before continuing." ;;

--- a/gnu-linux/uninstall.sh
+++ b/gnu-linux/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 #
 # Uninstallation script for Pombo.
 #

--- a/pombo.conf
+++ b/pombo.conf
@@ -131,6 +131,8 @@ screenshot=yes
 ; Take webcam shot?
 ; <filepath> will be replaced by a filename, do not customize (required).
 ; [W] yes or no
+; [L] /usr/bin/streamer -q -t 1 -r 2 -o  <filepath>
+; [L] /usr/bin/streamer -q -t 1 -r 2 -j 100 -s 640x480 -o <filepath>
 ; [L] /usr/bin/streamer -q -w 3 -o <filepath>
 ; [L] /usr/bin/streamer -q -j 100 -w 3 -s 640x480 -o <filepath>
 ; [L] /usr/bin/gst-launch -q v4l2src num_buffers=1 decimate=70 ! pngenc ! filesink location=<filepath>

--- a/pombo.py
+++ b/pombo.py
@@ -699,9 +699,9 @@ class Pombo(object):
                     "-r",
                     self.configuration["gpgkeyid"],
                     "-o",
-                    output,
-                    "-e",
                     output + ".gpg",
+                    "-e",
+                    output,
                 ]
             )
 


### PR DESCRIPTION
After trying to install and run Pombo, i discovered some issues which are fixed in this PR. 
Note: ubuntu 18.04 python 3.8.0

1 - install.sh and uninstall.sh scripts for linux uses #!/bin/sh -e
running the shell script with -e option abort script at first error. If some dependancies are missing, the error code 0 is generated by test=$(which ${package}) and the script is immediatly stopped without any information about the missing package 
proposal : install.sh and uninstall.sh scripts must uses #!/bin/sh 

2 - in install.sh command ‘python check-imports.py’ is not working: wrong path given
proposal : compute variable ${src_dir} corresponding to pombo main dir, uses this ${src_dir} everywhere it is needed
${src_dir}/tools/check-imports.py

3 - Which python version is used ?? 
Using multiple versions for python2 as well as for python3 on a system (this was the case for me) may lead to confusion (for which python version a missing package should be installed?). In some case, the shell script can use a different version then the terminal command. 
Proposal : install script now display python version used by install.sh (version which will be used by all shell scripts)

4 - Webcam shot using streamer under Ubuntu 18.04 issue
Using option ‘-w 3’ on my computer always give a dark image (it seems webcam don’t have enough time to adjust brightness). Is this bug related to my config ?  I didnt’t found any reference nor correction to this issue.  Replacing ‘w 3’ with ‘-t 1 r 2’ (take 1 frame, 2 frames per second) corrects this. Corresponding options have been added for Linux in pombo.conf

; [L] /usr/bin/streamer -q -t 1 -r 2 -o  <filepath>
; [L] /usr/bin/streamer -q -t 1 -r 2 -j 100 -s 640x480 -o <filepath>

5 - Pombo.py don’t generate the .gpg crypted file
Pombo.py  line 702: in generating gpg crypted file (-o) and  [files] (after -e ie input file) arguments where exchanged. 